### PR TITLE
standardized resource names, changed subnet size

### DIFF
--- a/infra/app/processor.bicep
+++ b/infra/app/processor.bicep
@@ -8,6 +8,7 @@ param runtimeName string
 param runtimeVersion string 
 param serviceName string = 'processor'
 param storageAccountName string
+param deploymentStorageContainerName string
 param virtualNetworkSubnetId string = ''
 param instanceMemoryMB int = 2048
 param maximumInstanceCount int = 100
@@ -34,6 +35,7 @@ module processor '../core/host/functions-flexconsumption.bicep' = {
     runtimeName: runtimeName
     runtimeVersion: runtimeVersion
     storageAccountName: storageAccountName
+    deploymentStorageContainerName: deploymentStorageContainerName
     virtualNetworkSubnetId: virtualNetworkSubnetId
     instanceMemoryMB: instanceMemoryMB 
     maximumInstanceCount: maximumInstanceCount

--- a/infra/app/vnet.bicep
+++ b/infra/app/vnet.bicep
@@ -32,7 +32,7 @@ resource virtualNetwork 'Microsoft.Network/virtualNetworks@2023-05-01' = {
         id: resourceId('Microsoft.Network/virtualNetworks/subnets', vNetName, 'private-endpoints-subnet')
         properties: {
           addressPrefixes: [
-            '10.0.1.0/28' // allows for 11 usable IP addresses
+            '10.0.1.0/24'
           ]
           delegations: []
           privateEndpointNetworkPolicies: 'Disabled'
@@ -45,7 +45,7 @@ resource virtualNetwork 'Microsoft.Network/virtualNetworks@2023-05-01' = {
         id: resourceId('Microsoft.Network/virtualNetworks/subnets', vNetName, 'app')
         properties: {
           addressPrefixes: [
-            '10.0.2.0/26' // allows for 59 usable IP addresses
+            '10.0.2.0/24'
           ]
           delegations: [
             {

--- a/infra/core/host/functions-flexconsumption.bicep
+++ b/infra/core/host/functions-flexconsumption.bicep
@@ -25,6 +25,7 @@ param kind string = 'functionapp,linux'
 param appSettings object = {}
 param instanceMemoryMB int = 2048
 param maximumInstanceCount int = 100
+param deploymentStorageContainerName string
 
 resource stg 'Microsoft.Storage/storageAccounts@2022-09-01' existing = {
   name: storageAccountName
@@ -47,7 +48,7 @@ resource functions 'Microsoft.Web/sites@2023-12-01' = {
       deployment: {
         storage: {
           type: 'blobContainer'
-          value: '${stg.properties.primaryEndpoints.blob}deploymentpackage'
+          value: '${stg.properties.primaryEndpoints.blob}${deploymentStorageContainerName}'
           authentication: {
             type: identityType == 'SystemAssigned' ? 'SystemAssignedIdentity' : 'UserAssignedIdentity'
             userAssignedIdentityResourceId: identityType == 'UserAssigned' ? identityId : '' 


### PR DESCRIPTION
- added dynamic deployment storage container name (as done in client tools).
- changed resource names to match what is done in Portal: private endpoints, privateDNSZone, DNSZoneGroupVirtualNetworkLink.
- changed the subnet size to be the standard size used by Portal create.
- moved the snippet that creates the app service plan up, right before where we create the function app (since they're logically associated).