### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,4 +127,3 @@ To provision:
 azd up
 ```
 
-Note that Visual Studio does not yet work to publish Flex Consumption apps. Please use Azure Functions Core Tools, Az CLI or VS Code alternatives instead to deploy your app zip to these Flex resources.


### PR DESCRIPTION
Removing note about dev tools for publishing. AZD now supports publishing to Flex Consumption and this note is not needed anymore.