### PR TITLE
Upgrade to .NET 10 and update NuGet packages

### DIFF
--- a/http/http.csproj
+++ b/http/http.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <AzureFunctionsVersion>v4</AzureFunctionsVersion>
     <OutputType>Exe</OutputType>
     <ImplicitUsings>enable</ImplicitUsings>
@@ -8,12 +8,12 @@
   </PropertyGroup>
   <ItemGroup>
     <FrameworkReference Include="Microsoft.AspNetCore.App" />
-    <PackageReference Include="Microsoft.Azure.Functions.Worker" Version="2.0.0" />
+    <PackageReference Include="Microsoft.Azure.Functions.Worker" Version="2.51.0" />
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.Http" Version="3.3.0" />
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.Http.AspNetCore" Version="2.0.2" />
-    <PackageReference Include="Microsoft.Azure.Functions.Worker.Sdk" Version="2.0.5" />
+    <PackageReference Include="Microsoft.Azure.Functions.Worker.Sdk" Version="2.0.7" />
     <PackageReference Include="Microsoft.ApplicationInsights.WorkerService" Version="2.23.0" />
-    <PackageReference Include="Microsoft.Azure.Functions.Worker.ApplicationInsights" Version="2.0.0" />
+    <PackageReference Include="Microsoft.Azure.Functions.Worker.ApplicationInsights" Version="2.50.0" />
   </ItemGroup>
   <ItemGroup>
     <None Update="host.json">

--- a/infra/main.bicep
+++ b/infra/main.bicep
@@ -110,7 +110,7 @@ module api './app/api.bicep' = {
     applicationInsightsName: monitoring.outputs.name
     appServicePlanId: appServicePlan.outputs.resourceId
     runtimeName: 'dotnet-isolated'
-    runtimeVersion: '8.0'
+    runtimeVersion: '10'
     storageAccountName: storage.outputs.name
     enableBlob: storageEndpointConfig.enableBlob
     enableQueue: storageEndpointConfig.enableQueue

--- a/infra/main.bicep
+++ b/infra/main.bicep
@@ -110,7 +110,7 @@ module api './app/api.bicep' = {
     applicationInsightsName: monitoring.outputs.name
     appServicePlanId: appServicePlan.outputs.resourceId
     runtimeName: 'dotnet-isolated'
-    runtimeVersion: '10'
+    runtimeVersion: '10.0'
     storageAccountName: storage.outputs.name
     enableBlob: storageEndpointConfig.enableBlob
     enableQueue: storageEndpointConfig.enableQueue


### PR DESCRIPTION
## Summary

Upgrades the template from .NET 8.0 to .NET 10 and updates NuGet packages to latest compatible versions.

Fixes #27

## Changes

**infra/main.bicep:**
- Changed `runtimeVersion: '8.0'` → `runtimeVersion: '10'`

**http/http.csproj:**
- Changed `<TargetFramework>net8.0</TargetFramework>` → `<TargetFramework>net10.0</TargetFramework>`
- Updated `Microsoft.Azure.Functions.Worker` 2.0.0 → 2.51.0
- Updated `Microsoft.Azure.Functions.Worker.Sdk` 2.0.5 → 2.0.7
- Updated `Microsoft.Azure.Functions.Worker.ApplicationInsights` 2.0.0 → 2.50.0
- **Kept `Microsoft.ApplicationInsights.WorkerService` at 2.23.0** (critical - see below)

## ⚠️ Important: ApplicationInsights 3.0 Breaking Change

`Microsoft.ApplicationInsights.WorkerService` is intentionally pinned to 2.23.0. Version 3.0.0+ introduces breaking changes with OpenTelemetry migration that are incompatible with `Microsoft.Azure.Functions.Worker.ApplicationInsights`:

```
TypeLoadException: Could not load type 'Microsoft.ApplicationInsights.Extensibility.ITelemetryInitializer'
from assembly 'Microsoft.ApplicationInsights, Version=3.0.0.1'
```

**Tracked in:** https://github.com/Azure/azure-functions-dotnet-worker/issues/3322